### PR TITLE
Optimize CTQueue with Linked List for O(1) Dequeue

### DIFF
--- a/src/Containers-Queue-Tests/CTQueueTest.class.st
+++ b/src/Containers-Queue-Tests/CTQueueTest.class.st
@@ -60,3 +60,22 @@ CTQueueTest >> testQueue [
 CTQueueTest >> testQueueGarantyFIFOOrder [
 	self assert: self queueClass new isEmpty
 ]
+
+{ #category : #tests }
+CTQueueTest >> testDequeueEmpty [
+	"Test dequeue on an empty queue raises an error."
+	| queue |
+	queue := self queueClass new.
+	self should: [ queue dequeue ] raise: Error description: 'Queue is empty'.
+]
+
+{ #category : #tests }
+CTQueueTest >> testLargeQueueFIFO [
+	"Test FIFO order with a larger dataset."
+	| queue size |
+	queue := self queueClass new.
+	size := 1000.
+	1 to: size do: [ :i | queue queue: i ].
+	1 to: size do: [ :i | self assert: queue dequeue equals: i ].
+	self assert: queue isEmpty.
+]

--- a/src/Containers-Queue/CTQueue.class.st
+++ b/src/Containers-Queue/CTQueue.class.st
@@ -1,91 +1,114 @@
-"
-I'm a simple FIFO queue i.e., first in first out structure. I support basic collection protocol and in addition enqueue and dequeue as in Scala. 
-My basic support of collection API should be reviewd and probably improved (should check atomic queue protocol).
-
-
-"
 Class {
 	#name : #CTQueue,
 	#superclass : #Object,
 	#instVars : [
-		'elements'
+		'head',
+		'tail'
 	],
 	#category : #'Containers-Queue'
 }
 
-{ #category : #testing }
+{ #category : #adding }
 CTQueue >> add: anElement [
-	"Add an element to the receiver. Note that the addition makes sure that when iterating over the receiver added first element are accessed first."
-	
-	elements addLast: anElement.
-	^ anElement
+	"Add an element to the end of the queue (FIFO order)."
+	^ self queue: anElement
 ]
 
-{ #category : #testing }
+{ #category : #adding }
 CTQueue >> addAll: aCollection [
-	"Add the elements contained in the argument to the receiver. Note that the addition makes sure that when iterating over the receiver added first element are accessed first."
-	
-	elements addAllLast: aCollection.
+	"Add all elements from aCollection to the end of the queue."
+	aCollection do: [ :each | self queue: each ].
 	^ aCollection
 ]
 
 { #category : #accessing }
 CTQueue >> at: anIndex [
-	"Accessed the element to the given index in the receiver according to the adding order."
-	^ elements at: anIndex
+	"Access the element at the given 1-based index in FIFO order."
+	| current index |
+	(anIndex < 1) ifTrue: [ self error: 'Index out of bounds' ].
+	current := head.
+	index := 1.
+	[ current isNil or: [ index = anIndex ] ] whileFalse: [ 
+		current := current next.
+		index := index + 1.
+	].
+	current ifNil: [ self error: 'Index out of bounds' ].
+	^ current value
 ]
 
-{ #category : #'adding/removing' }
+{ #category : #removing }
 CTQueue >> dequeue [
-	"Return the older element of the receiver.."
-	
-	^ elements removeFirst
+	"Remove and return the oldest element (FIFO)."
+	| value |
+	head ifNil: [ self error: 'Queue is empty' ].
+	value := head value.
+	head := head next.
+	head ifNil: [ tail := nil ].
+	^ value
 ]
 
-{ #category : #'adding/removing' }
+{ #category : #removing }
 CTQueue >> dequeueIfNone: aBlock [
-	"Return the older element of the receiver.."
-	elements ifEmpty: [ aBlock value ].
-	^ elements removeFirst
+	"Remove and return the oldest element, or evaluate aBlock if empty."
+	head ifNil: [ ^ aBlock value ].
+	^ self dequeue
 ]
 
 { #category : #iterating }
 CTQueue >> do: aBlock [
-	"iterates the elements of the receiver starting first by first added elements."
-	
-	self do: aBlock
+	"Iterate over elements in FIFO order."
+	| current |
+	current := head.
+	[ current notNil ] whileTrue: [ 
+		aBlock value: current value.
+		current := current next.
+	]
 ]
 
 { #category : #testing }
 CTQueue >> includes: anElement [
-
-	^ elements includes: anElement
+	"Check if anElement exists in the queue."
+	| current |
+	current := head.
+	[ current notNil ] whileTrue: [ 
+		current value = anElement ifTrue: [ ^ true ].
+		current := current next.
+	].
+	^ false
 ]
 
 { #category : #initialization }
 CTQueue >> initialize [
+	"Initialize an empty queue."
 	super initialize.
-	elements := OrderedCollection new. 
+	head := nil.
+	tail := nil.
 ]
 
 { #category : #testing }
 CTQueue >> isEmpty [
-
-	^ elements isEmpty
+	"Return true if the queue is empty."
+	^ head isNil
 ]
 
-{ #category : #'adding/removing' }
+{ #category : #adding }
 CTQueue >> queue: anElement [
-	"Add an element to the receiver. Note that the addition makes sure that when iterating over the receiver added first element are accessed first."
-	
-	elements addLast: anElement.
+	"Add an element to the end of the queue (FIFO order)."
+	| newNode |
+	newNode := CTQueueNode new value: anElement.
+	head ifNil: [ 
+		head := newNode.
+		tail := newNode.
+	] ifNotNil: [ 
+		tail next: newNode.
+		tail := newNode.
+	].
 	^ anElement
 ]
 
-{ #category : #'adding/removing' }
+{ #category : #adding }
 CTQueue >> queueAll: aCollection [
-	"Add the elements contained in the argument to the receiver. Note that the addition makes sure that when iterating over the receiver added first element are accessed first."
-	
-	elements addAllLast: aCollection.
+	"Add all elements from aCollection to the end of the queue."
+	aCollection do: [ :each | self queue: each ].
 	^ aCollection
 ]

--- a/src/Containers-Queue/CTQueueNode.class.st
+++ b/src/Containers-Queue/CTQueueNode.class.st
@@ -1,0 +1,29 @@
+Class {
+	#name : #CTQueueNode,
+	#superclass : #Object,
+	#instVars : [
+		'value',
+		'next'
+	],
+	#category : #'Containers-Queue'
+}
+
+{ #category : #accessing }
+CTQueueNode >> next [
+	^ next
+]
+
+{ #category : #accessing }
+CTQueueNode >> next: aNode [
+	next := aNode
+]
+
+{ #category : #accessing }
+CTQueueNode >> value [
+	^ value
+]
+
+{ #category : #accessing }
+CTQueueNode >> value: anObject [
+	value := anObject
+]


### PR DESCRIPTION
This PR fixes #9 by replacing OrderedCollection in CTQueue with a singly linked list using a new CTQueueNode class. Key changes:

dequeue improved from O(n) to O(1).
queue: remains O(1).
**Added CTQueueNode. Why?**
CTQueueNode is the building block that makes the efficient linked list possible, directly addressing the performance.

Updated CTQueue methods and tests (testDequeueEmpty, testLargeQueueFIFO).
Why: The old removeFirst was inefficient for large queues. This aligns with the project’s goal of efficient collections.

Test: Load in Pharo, run CTQueueTest, and try a large queue (e.g., 10,000 elements).